### PR TITLE
Pass error callbacks message object; make programmatic logging possible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Change Log
 ===========
 
+1.12.27
+-------
+
+- Pass entire message to handleError callback
+- Add ezIBpy logging kwarg to enable logging
+
 1.12.26
 -------
 

--- a/ezibpy/ezibpy.py
+++ b/ezibpy/ezibpy.py
@@ -40,8 +40,7 @@ from stat import S_IWRITE
 # =============================================================
 import logging
 # import sys
-# logging.basicConfig(stream=sys.stdout, level=self.log(mode="debug", msg=
-    # format='%(asctime)s [%(levelname)s]: %(message)s')
+# logging.basicConfig(stream=sys.stderr, level=logging.DEBUG, format='%(asctime)s [%(levelname)s]: %(message)s')
 
 
 class ezIBpy():
@@ -70,11 +69,11 @@ class ezIBpy():
     https://www.interactivebrokers.com/en/software/api/apiguide/java/java_eclientsocket_methods.htm
     """
     # ---------------------------------------------------------
-    def __init__(self):
+    def __init__(self, logging=False):
 
         self.__version__   = 0.09
 
-        self.logging       = False
+        self.logging       = logging
 
         self.clientId      = 1
         self.port          = 4001 # 7496/7497 = TWS, 4001 = IBGateway
@@ -208,7 +207,7 @@ class ezIBpy():
         # https://www.interactivebrokers.com/en/software/api/apiguide/tables/api_message_codes.htm
         if msg.errorCode != -1: # and msg.errorCode != 2104 and msg.errorCode != 2106:
             self.log(mode="error", msg=msg)
-            self.ibCallback(caller="handleError", msg=msg.errorCode)
+            self.ibCallback(caller="handleError", msg=msg)
 
     # ---------------------------------------------------------
     def handleServerEvents(self, msg):


### PR DESCRIPTION
`handleErrorEvents()` was calling `ibCallback()` with a `msg` consisting of just the
integer error code.  The other callbacks all expect a message object.  Passing
the full object allows clients to handle messages uniformly and extract the
error message text.

Added `logging=False` kwarg to `ezIBpy.__init__()` to make logging possible.

It seems like maybe `izIBpy()` was avoiding kwargs by design, so if another method is preferred (a `configure()` method or something) that's fine.

Also, it's not clear what the `ezIBpy.log()` method buys: it would be less typing to just use `logging.info()` and friends directly, and you would only have to enable logging in one place, using the standard Python method.  Seems simpler, but I refrained from refactoring.