### PR TITLE
Create DisconnectLoopFix

### DIFF
--- a/DisconnectLoopFix
+++ b/DisconnectLoopFix
@@ -1,0 +1,7 @@
+def disconnect(self):
+   """ Disconnect from TWS/IBGW """
+   if self.ibConn is not None:
+      self.connected = False
+      self.log.info("[DISCONNECT FROM IB]")
+      time.sleep(1)
+      self.ibConn.disconnect()


### PR DESCRIPTION
Hey again, your library is super useful to me... I did a little digging into the EClientSocket disconnect method (the native API not the IbPy one) and was able to fix the error of the endless loop when trying to disconnect. It now works for submitting multiple different orders even if some are open / pending. This solves the #326 error... I hope I'm being more helpful than annoying. lol

Thanks again, 

Tyler